### PR TITLE
chore: prefix meetings in redis by `meeting:` #62

### DIFF
--- a/pkg/app/handlers_test.go
+++ b/pkg/app/handlers_test.go
@@ -266,7 +266,7 @@ func TestCreate(t *testing.T) {
 						Body:       ioutil.NopCloser(bytes.NewReader(response)),
 					}, nil
 				}
-				redisMock.ExpectSet(meetingID, instance, 0).SetErr(errors.New("redis error"))
+				redisMock.ExpectSet(cacheKey(meetingID), instance, 0).SetErr(errors.New("redis error"))
 			},
 			Validator: func(t *testing.T, value interface{}, err error) {
 				assert.Equal(t, http.StatusInternalServerError, w.Code)
@@ -307,7 +307,7 @@ func TestCreate(t *testing.T) {
 						Body:       ioutil.NopCloser(bytes.NewReader(response)),
 					}, nil
 				}
-				redisMock.ExpectSet(meetingID, instance, 0).SetVal(meetingID)
+				redisMock.ExpectSet(cacheKey(meetingID), instance, 0).SetVal(meetingID)
 			},
 			Validator: func(t *testing.T, value interface{}, err error) {
 				response := unMarshallCreateResponse(w.Body.Bytes())
@@ -356,7 +356,7 @@ func TestJoin(t *testing.T) {
 			Name: "Providing a meeting id that does not exists should return a not found error",
 			Mock: func() {
 				test.SetRequestParams(c, params)
-				redisMock.ExpectGet(meetingID).SetVal("")
+				redisMock.ExpectGet(cacheKey(meetingID)).SetVal("")
 				checksum := &api.Checksum{
 					Secret: test.DefaultSecret(),
 					Params: params,
@@ -376,7 +376,7 @@ func TestJoin(t *testing.T) {
 			Name: "Providing a meeting id that does not match an instance should return a not found error",
 			Mock: func() {
 				test.SetRequestParams(c, params)
-				redisMock.ExpectGet(meetingID).SetVal(instance)
+				redisMock.ExpectGet(cacheKey(meetingID)).SetVal(instance)
 				redisMock.ExpectHGet(admin.B3LBInstances, instance).SetVal("")
 				checksum := &api.Checksum{
 					Secret: test.DefaultSecret(),
@@ -397,7 +397,7 @@ func TestJoin(t *testing.T) {
 			Name: "A valid request should redirect to the meeting url",
 			Mock: func() {
 				test.SetRequestParams(c, params)
-				redisMock.ExpectGet(meetingID).SetVal(instance)
+				redisMock.ExpectGet(cacheKey(meetingID)).SetVal(instance)
 				redisMock.ExpectHGet(admin.B3LBInstances, instance).SetVal(test.DefaultSecret())
 				checksum := &api.Checksum{
 					Secret: test.DefaultSecret(),
@@ -415,7 +415,7 @@ func TestJoin(t *testing.T) {
 			Name: "An error return by BigBlueButton instance while calling join api with `redirect=false` parameter set should return an internal server error status code",
 			Mock: func() {
 				test.SetRequestParams(c, fmt.Sprintf("%s&redirect=false", params))
-				redisMock.ExpectGet(meetingID).SetVal(instance)
+				redisMock.ExpectGet(cacheKey(meetingID)).SetVal(instance)
 				redisMock.ExpectHGet(admin.B3LBInstances, instance).SetVal(test.DefaultSecret())
 				checksum := &api.Checksum{
 					Secret: test.DefaultSecret(),
@@ -435,7 +435,7 @@ func TestJoin(t *testing.T) {
 			Name: "Calling join api with `redirect=false` parameter set should return a valid JoinRedirectResponse",
 			Mock: func() {
 				test.SetRequestParams(c, fmt.Sprintf("%s&redirect=false", params))
-				redisMock.ExpectGet(meetingID).SetVal(instance)
+				redisMock.ExpectGet(cacheKey(meetingID)).SetVal(instance)
 				redisMock.ExpectHGet(admin.B3LBInstances, instance).SetVal(test.DefaultSecret())
 				checksum := &api.Checksum{
 					Secret: test.DefaultSecret(),
@@ -497,7 +497,7 @@ func TestEnd(t *testing.T) {
 			Name: "An error thrown by SessionManager removing session should return an http interal server error",
 			Mock: func() {
 				test.SetRequestParams(c, params)
-				redisMock.ExpectGet(meetingID).SetVal(instance)
+				redisMock.ExpectGet(cacheKey(meetingID)).SetVal(instance)
 				redisMock.ExpectHGet(admin.B3LBInstances, instance).SetVal(test.DefaultSecret())
 				checksum := &api.Checksum{
 					Secret: test.DefaultSecret(),
@@ -505,7 +505,7 @@ func TestEnd(t *testing.T) {
 					Action: api.IsMeetingRunning,
 				}
 				c.Set("api_ctx", checksum)
-				redisMock.ExpectDel(meetingID).SetErr(errors.New("error"))
+				redisMock.ExpectDel(cacheKey(meetingID)).SetErr(errors.New("error"))
 				RestClientMock.DoFunc = func(req *http.Request) (*http.Response, error) {
 					endResponse := &api.EndResponse{
 						Response: api.Response{
@@ -532,7 +532,7 @@ func TestEnd(t *testing.T) {
 			Name: "A valid end call should return a success response",
 			Mock: func() {
 				test.SetRequestParams(c, params)
-				redisMock.ExpectGet(meetingID).SetVal(instance)
+				redisMock.ExpectGet(cacheKey(meetingID)).SetVal(instance)
 				redisMock.ExpectHGet(admin.B3LBInstances, instance).SetVal(test.DefaultSecret())
 				checksum := &api.Checksum{
 					Secret: test.DefaultSecret(),
@@ -540,7 +540,7 @@ func TestEnd(t *testing.T) {
 					Action: api.IsMeetingRunning,
 				}
 				c.Set("api_ctx", checksum)
-				redisMock.ExpectDel(meetingID).SetVal(1)
+				redisMock.ExpectDel(cacheKey(meetingID)).SetVal(1)
 				RestClientMock.DoFunc = func(req *http.Request) (*http.Response, error) {
 					endResponse := &api.EndResponse{
 						Response: api.Response{
@@ -603,7 +603,7 @@ func TestIsMeetingRunning(t *testing.T) {
 			Name: "Providing a meeting id that does not exists should return a not found error",
 			Mock: func() {
 				test.SetRequestParams(c, params)
-				redisMock.ExpectGet(meetingID).SetVal("")
+				redisMock.ExpectGet(cacheKey(meetingID)).SetVal("")
 				checksum := &api.Checksum{
 					Secret: test.DefaultSecret(),
 					Params: params,
@@ -623,7 +623,7 @@ func TestIsMeetingRunning(t *testing.T) {
 			Name: "Providing a meeting id that does not match an instance should return a not found error",
 			Mock: func() {
 				test.SetRequestParams(c, params)
-				redisMock.ExpectGet(meetingID).SetVal(instance)
+				redisMock.ExpectGet(cacheKey(meetingID)).SetVal(instance)
 				redisMock.ExpectHGet(admin.B3LBInstances, instance).SetVal("")
 				checksum := &api.Checksum{
 					Secret: test.DefaultSecret(),
@@ -644,7 +644,7 @@ func TestIsMeetingRunning(t *testing.T) {
 			Name: "An error thrown by remote bigbluebutton instance should return an http internal error status",
 			Mock: func() {
 				test.SetRequestParams(c, params)
-				redisMock.ExpectGet(meetingID).SetVal(instance)
+				redisMock.ExpectGet(cacheKey(meetingID)).SetVal(instance)
 				redisMock.ExpectHGet(admin.B3LBInstances, instance).SetVal(test.DefaultSecret())
 				checksum := &api.Checksum{
 					Secret: test.DefaultSecret(),
@@ -664,7 +664,7 @@ func TestIsMeetingRunning(t *testing.T) {
 			Name: "A valid request should return a valid response",
 			Mock: func() {
 				test.SetRequestParams(c, params)
-				redisMock.ExpectGet(meetingID).SetVal(instance)
+				redisMock.ExpectGet(cacheKey(meetingID)).SetVal(instance)
 				redisMock.ExpectHGet(admin.B3LBInstances, instance).SetVal(test.DefaultSecret())
 				checksum := &api.Checksum{
 					Secret: test.DefaultSecret(),
@@ -723,7 +723,7 @@ func TestGetMeetingInfo(t *testing.T) {
 			Name: "A valid end call should return a success response",
 			Mock: func() {
 				test.SetRequestParams(c, params)
-				redisMock.ExpectGet(meetingID).SetVal(instance)
+				redisMock.ExpectGet(cacheKey(meetingID)).SetVal(instance)
 				redisMock.ExpectHGet(admin.B3LBInstances, instance).SetVal(test.DefaultSecret())
 				checksum := &api.Checksum{
 					Secret: test.DefaultSecret(),

--- a/pkg/app/session_manager.go
+++ b/pkg/app/session_manager.go
@@ -27,23 +27,28 @@ func NewSessionManager(rdb redis.Client) SessionManager {
 	}
 }
 
+// cacheKey format meetingID as a valid meeting cache key
+func cacheKey(id string) string {
+	return "meeting:" + id
+}
+
 // Add persist the session in the redis database
 func (m *RedisSessionManager) Add(sessionID string, host string) error {
-	_, err := m.RDB.Set(context.Background(), sessionID, host, 0).Result()
+	_, err := m.RDB.Set(context.Background(), cacheKey(sessionID), host, 0).Result()
 
 	return utils.ComputeErr(err)
 }
 
 // Get retrieve the session from the redis database
 func (m *RedisSessionManager) Get(sessionID string) (string, error) {
-	host, err := m.RDB.Get(context.Background(), sessionID).Result()
+	host, err := m.RDB.Get(context.Background(), cacheKey(sessionID)).Result()
 
 	return host, utils.ComputeErr(err)
 }
 
 // Remove remove the session from the redis database
 func (m *RedisSessionManager) Remove(sessionID string) error {
-	_, err := m.RDB.Del(context.Background(), sessionID).Result()
+	_, err := m.RDB.Del(context.Background(), cacheKey(sessionID)).Result()
 
 	return utils.ComputeErr(err)
 }

--- a/pkg/app/session_manager_test.go
+++ b/pkg/app/session_manager_test.go
@@ -13,12 +13,16 @@ import (
 const sessionID string = "session_id"
 const host string = "http://localhost/bigbluebutton"
 
+func TestCacheKey(t *testing.T) {
+	assert.Equal(t, "meeting:session_id", cacheKey(sessionID))
+}
+
 func TestAdd(t *testing.T) {
 	tests := []test.Test{
 		{
 			Name: "Add should not return and error if the value is added",
 			Mock: func() {
-				mock := redisMock.ExpectSet(sessionID, host, 0)
+				mock := redisMock.ExpectSet(cacheKey(sessionID), host, 0)
 				mock.SetErr(redis.Nil)
 			},
 			Validator: func(t *testing.T, value interface{}, err error) {
@@ -28,7 +32,7 @@ func TestAdd(t *testing.T) {
 		{
 			Name: "Add should return an error if redis throws an error",
 			Mock: func() {
-				mock := redisMock.ExpectSet(sessionID, host, 0)
+				mock := redisMock.ExpectSet(cacheKey(sessionID), host, 0)
 				mock.SetErr(errors.New("redis error"))
 			},
 			Validator: func(t *testing.T, value interface{}, err error) {
@@ -51,7 +55,7 @@ func TestGet(t *testing.T) {
 		{
 			Name: "Get should return the host and no error if the session is found",
 			Mock: func() {
-				redisMock.ExpectGet(sessionID).SetVal(host)
+				redisMock.ExpectGet(cacheKey(sessionID)).SetVal(host)
 			},
 			Validator: func(t *testing.T, value interface{}, err error) {
 				assert.Nil(t, err)
@@ -61,7 +65,7 @@ func TestGet(t *testing.T) {
 		{
 			Name: "Get should return an error if redis throws an error",
 			Mock: func() {
-				mock := redisMock.ExpectGet(sessionID)
+				mock := redisMock.ExpectGet(cacheKey(sessionID))
 				mock.SetErr(errors.New("redis error"))
 			},
 			Validator: func(t *testing.T, value interface{}, err error) {
@@ -71,7 +75,7 @@ func TestGet(t *testing.T) {
 		{
 			Name: "Get should return an empty string if the session is not found",
 			Mock: func() {
-				redisMock.ExpectGet(sessionID).SetVal("")
+				redisMock.ExpectGet(cacheKey(sessionID)).SetVal("")
 			},
 			Validator: func(t *testing.T, value interface{}, err error) {
 				assert.Nil(t, err)
@@ -94,7 +98,7 @@ func TestRemove(t *testing.T) {
 		{
 			Name: "Remove should return nil if the session is removed",
 			Mock: func() {
-				redisMock.ExpectDel(sessionID).SetErr(redis.Nil)
+				redisMock.ExpectDel(cacheKey(sessionID)).SetErr(redis.Nil)
 			},
 			Validator: func(t *testing.T, value interface{}, err error) {
 				assert.Nil(t, err)
@@ -103,7 +107,7 @@ func TestRemove(t *testing.T) {
 		{
 			Name: "Remove should return an error if redis throws an error",
 			Mock: func() {
-				redisMock.ExpectDel(sessionID).SetErr(errors.New("redis error"))
+				redisMock.ExpectDel(cacheKey(sessionID)).SetErr(errors.New("redis error"))
 			},
 			Validator: func(t *testing.T, value interface{}, err error) {
 				assert.NotNil(t, err)


### PR DESCRIPTION
resolve #62